### PR TITLE
Typo

### DIFF
--- a/src/latex_of_wiki/doclink.ml
+++ b/src/latex_of_wiki/doclink.ml
@@ -98,7 +98,7 @@ let parse_uid id =
 
 let parse_method id =
   match String.split '#' id with
-  | [id; mid] when not (is_capitalized id) && not (is_capitalized id) -> (id, mid)
+  | [id; mid] when not (is_capitalized id) && not (is_capitalized mid) -> (id, mid)
   | _ -> raise (Error (Printf.sprintf "invalid method name %S" id))
 
 let parse_api_contents args contents =


### PR DESCRIPTION
See also https://github.com/ocsigen/ocsigen.org/pull/26. I guess the code was copy/pasted between projects.