### PR TITLE
Minimize markup in variand and field descriptions.

### DIFF
--- a/src/odoc_wiki/odoc_wiki.ml
+++ b/src/odoc_wiki/odoc_wiki.ml
@@ -536,10 +536,16 @@ class virtual info =
        @param indent can be specified not to use the style of info comments;
        default is [true].
     *)
-    method html_of_info ?(indent=true) b info_opt =
+    method html_of_info ?(no_markup=false) ?(indent=true) b info_opt =
       match info_opt with
         None ->
           ()
+      | Some info when no_markup ->
+          (
+           match info.Odoc_info.i_desc with
+             None -> ()
+           | Some d -> bs b (self#escape (Odoc_text.Texter.string_of_text d))
+          )
       | Some info ->
           let module M = Odoc_info in
           if indent then bs b "<<div class=\"odocwiki_info\"|";
@@ -1234,7 +1240,7 @@ class wiki =
              | Some t ->
                  bs b "<<span class=\"odocwiki_comments\"|";
                  bp b "<<span class=\"odocwiki_comments_open\"|(*>> <<span|";
-                 self#html_of_info b (Some t);
+                 self#html_of_info ~no_markup: true b (Some t);
                  bp b ">><<span class=\"odocwiki_comments_close\"| ~*)>>";
                  bs b ">>";
             );
@@ -1263,7 +1269,7 @@ class wiki =
              | Some t ->
                  bs b "<<span class=\"odocwiki_comments\"|";
                  bp b "<<span class=\"odocwiki_comments_open\"|(*>> <<span|";
-                 self#html_of_info b (Some t);
+                 self#html_of_info ~no_markup: true b (Some t);
                  bp b ">><<span class=\"odocwiki_comments_close\"| ~*)>>";
                  bs b ">>";
             );
@@ -1490,7 +1496,7 @@ class wiki =
       if info then
         (
          if complete then
-           self#html_of_info ~indent: false
+           self#html_of_info ?no_markup: None ~indent: false
          else
            self#html_of_info_first_sentence
         ) b m.m_info
@@ -1521,7 +1527,7 @@ class wiki =
       if info then
         (
          if complete then
-           self#html_of_info ~indent: false
+           self#html_of_info ?no_markup: None ~indent: false
          else
            self#html_of_info_first_sentence
         ) b mt.mt_info
@@ -1678,7 +1684,7 @@ class wiki =
       bs b ">>" ;
       (
        if complete then
-         self#html_of_info ~indent: false
+         self#html_of_info ?no_markup: None ~indent: false
        else
          self#html_of_info_first_sentence
       ) b c.cl_info
@@ -1721,7 +1727,7 @@ class wiki =
       bs b ">>";
       (
        if complete then
-         self#html_of_info ~indent: false
+         self#html_of_info ?no_markup: None ~indent: false
        else
          self#html_of_info_first_sentence
       ) b ct.clt_info


### PR DESCRIPTION
`ocsigen.org`'s styles and parser currently assume that variand and field descriptions are simple preformatted comment strings. Meanwhile, `wikidoc`, like `ocamldoc`, expects the descriptions to be table cells with full documentation styling and block content.

This commit changes `wikidoc` to output the descriptions as text close to what is written in the source code, inserting much less markup.

I inspected the new output, and it looks correct up to my understanding of Wiki Creole and Ocsigen's extensions. I haven't tested final display on `ocisgen.org`.

I think the "right way" to fix this is to change the style and layout on `ocsigen.org` to allow block content in variand info, like `ocamldoc` does. However, that seems like an involved project that I'm not ready to do right now. Perhaps that can be done at a later date.

In the meantime, this helps to fix https://github.com/ocsigen/ocsigen.org/issues/19. To complete the fix, I will also remove `ocamldoc` markup from variands in `lwt_unix.mli`.