### PR TITLE
Fix version issue

### DIFF
--- a/src/odoc_wiki/odoc_import.ml
+++ b/src/odoc_wiki/odoc_import.ml
@@ -93,7 +93,7 @@ let string_of_type_param_list ?margin t =
     (if par then "(" else "")
     (raw_string_of_type_list ?margin ", "
        (List.map
-          (fun (typ, co, cn) -> (Odoc_str.string_of_variance t (co, cn), typ))
+          (fun (typ, v) -> (Odoc_str.string_of_variance t v, typ))
           t.Odoc_type.ty_parameters
        )
     )

--- a/wikidoc.opam
+++ b/wikidoc.opam
@@ -18,7 +18,7 @@ remove: [
   [ "rm" "-f" "%{bin}%/latex_of_wiki" ]
 ]
 depends: [
-  "ocaml" {>= "4.14.0" & < "5.1.0"}
+  "ocaml" {> "5.1.0" }
   "base-threads"
   "base-unix"
   "ocamlfind"


### PR DESCRIPTION
# **Ne pas merge, il y a un soucis au niveau du dernier commit !!!!**
En effet, cela ne fonctionne pas avec la version ocaml 5.1.0.
Lors du passage d'OCaml 5.0.0 à OCaml 5.1.0, il y a des fichiers .mli qui ont été ajouté au projet OCaml.

Voici la pull request qui ajoutait des fichiers .mli : https://github.com/ocaml/ocaml/pull/11288

Voici le fameux fichier .mli, celui qui pose soucis, qui a été ajouté lors de cette pull request : https://github.com/ocaml/ocaml/blob/trunk/ocamldoc/odoc_html.mli

Il manque la classe class virtual text dans le fichier .mli, voici un lien vers cette classe : https://github.com/ocaml/ocaml/blob/201b0ac48269c67c5667d0c2de49070384386a2c/ocamldoc/odoc_html.ml#L246

Voici où cette classe a été utilisé dans le projet wikidoc : https://github.com/ocsigen/wikidoc/blob/a711eb3f588176e0dc73a37dff55c45bcbface94/src/odoc_wiki/odoc_wiki.ml#L169

Voici l'erreur que j'ai dans le projet wikidoc lorsque j'essaye de compiler :
`Error: Unbound class Odoc_html.text`


## Ocaml  4.13 : modification d'un type  
```
File "odoc_import.ml", line 35, characters 23-38:
35 |     | Types.Tlink t2 | Types.Tsubst t2 -> need_parent t2
                            ^^^^^^^^^^^^^^^
Error: The constructor Types.Tsubst expects 2 argument(s),
       but is applied here to 1 argument(s)
make[1]: *** [Makefile:45: odoc_import.cmo] Error 2
```

Vient de ce changement :
https://github.com/ocaml/ocaml/pull/10174

Avant :
```ocaml
| Tsubst of type_expr         (* for copying *)
  (** [Tsubst] is used temporarily to store information in low-level
      functions manipulating representation of types, such as
      instantiation or copy.
```
Après :
```ocaml
| Tsubst of type_expr * type_expr option
  (** [Tsubst] is used temporarily to store information in low-level
      functions manipulating representation of types, such as
      instantiation or copy.
      The first argument contains a copy of the original node.
      The second is available only when the first is the row variable of
      a polymorphic variant.  It then contains a copy of the whole variant.
```

J'ai donc modifié en ignorant le second argument et ça marche :
```ocaml
  | Types.Tlink t2 | Types.Tsubst (t2, _) -> is_arrow_type t2
```

Après j'ai pas trop compris le message de la PR, mais ça dit bien que c'est un extra argument:
> The constructor Tsubst of type_desc has only one type_expr as its argument while it needs two during a copy.
> The two values are currently packed as a Ttuple and wrapped in an extra type_expr before they are fed to Tsubst.
> This style looks quite ad-hoc, and moreover it turned out to be an obstacle in our (@garrigue and me) attempt to make
type_expr an abstract type.
> This PR adds to Tsubst another argument of type type_expr option to eliminate that hackish use of Ttuple.

## Supression d'un warning
Simple changement d'appel de fonction :
```
-           self#html_of_record b indent father l ;
+           self#html_of_record b ~indent ~father l ;
```
Les labels étaient pas préciser ce qui cause maintenant un warning
## mark_loops erreurs
printtyp.mark_loops a disparu à ce commit là : https://github.com/ocaml/ocaml/pull/10488/files

Updated ocamldoc to the new API by: (1) removing unncessary calls to Printtyp.mark_loops which were handled by the formatters; and
(2) replacing Printtyp.type_scheme_max ~b_reset_names: false with Printtyp.shared_type_scheme.

Files modified:

    ocamldoc/odoc_env.ml
    ocamldoc/odoc_print.ml
    ocamldoc/odoc_str.ml
    ocamldoc/odoc_value.ml




Il y a certain morceaux de code qui cause des erreurs quasi identique dans odoc_str.ml, ceux-ci ont été modifié. J'ai donc juste eu à copié les changement.
Y a un autre morceau de code qui n'était pas quasi identique mais ressemblait.
J'ai suivi la recommandation : (2) replacing Printtyp.type_scheme_max ~b_reset_names: false with Printtyp.shared_type_scheme

En ce qui concerne la supression de Printtyp.mark_loops t, c'est dis dans le premier conseil qu'il faut suprimé quand c'est "handled by the formatters", et juste après notre Printtyp.mark_loops t, y a un fmt :
	  Format.fprintf fmt "@[<hov 2>%s%s%a%s@] ->@ "
Donc j'ai supprimé.


