### PR TITLE
Fix version issue before 5.1

### DIFF
--- a/src/odoc_wiki/Makefile
+++ b/src/odoc_wiki/Makefile
@@ -8,9 +8,9 @@ OCAMLDUCEFIND ?= ocamlducefind
 OCAMLDOC     ?= ${OCAMLFIND} ocamldoc
 OCAMLDUCEDOC ?= ${OCAMLDUCEFIND} ocamldoc
 
-OCAMLC       ?= ${OCAMLFIND} ocamlc
+OCAMLC       ?= ${OCAMLFIND} ocamlc -package str 
 OCAMLDUCEC   ?= ${OCAMLDUCEFIND} ocamlc
-OCAMLOPT     ?= ${OCAMLFIND} ocamlopt
+OCAMLOPT     ?= ${OCAMLFIND} ocamlopt -package str
 OCAMLDUCEOPT ?= ${OCAMLDUCEFIND} ocamlopt
 OCAMLDEP     ?= ${OCAMLFIND} ocamldep
 OCAMLDUCEDEP ?= ${OCAMLDUCEFIND} ocamldep

--- a/src/odoc_wiki/odoc_import.ml
+++ b/src/odoc_wiki/odoc_import.ml
@@ -32,7 +32,7 @@ let raw_string_of_type_list ?(margin = default_margin) sep type_list =
   let rec need_parent t =
     match t.Types.desc with
       Types.Tarrow _ | Types.Ttuple _ -> true
-    | Types.Tlink t2 | Types.Tsubst t2 -> need_parent t2
+    | Types.Tlink t2 | Types.Tsubst (t2, _) -> need_parent t2
     | Types.Tconstr _ ->
         false
     (* | Types.Tvar | Types.Tunivar | Types.Tobject _ | Types.Tpoly _ *)
@@ -120,7 +120,7 @@ let string_of_class_type_param_list ?margin l =
 let rec is_arrow_type t =
   match t.Types.desc with
     Types.Tarrow _ -> true
-  | Types.Tlink t2 | Types.Tsubst t2 -> is_arrow_type t2
+  | Types.Tlink t2 | Types.Tsubst (t2, _) -> is_arrow_type t2
   (* | Types.Ttuple _ *)
   (* | Types.Tconstr _ *)
   (* | Types.Tvar | Types.Tunivar | Types.Tobject _ | Types.Tpoly _ *)

--- a/src/odoc_wiki/odoc_import.ml
+++ b/src/odoc_wiki/odoc_import.ml
@@ -21,8 +21,7 @@ let (modtype_fmt, flush_modtype_fmt, modtype_set_margin) = new_fmt ()
 
 let string_of_type_expr ?(margin = default_margin) t =
   type_set_margin margin;
-  Printtyp.mark_loops t;
-  Printtyp.type_scheme_max ~b_reset_names: false type_fmt t;
+  Printtyp.shared_type_scheme type_fmt t;
   flush_type_fmt ()
 
 let raw_string_of_type_list ?(margin = default_margin) sep type_list =
@@ -30,7 +29,7 @@ let raw_string_of_type_list ?(margin = default_margin) sep type_list =
   let fmt = Format.formatter_of_buffer buf in
   Format.pp_set_margin fmt margin;
   let rec need_parent t =
-    match t.Types.desc with
+    match Types.get_desc t with
       Types.Tarrow _ | Types.Ttuple _ -> true
     | Types.Tlink t2 | Types.Tsubst (t2, _) -> need_parent t2
     | Types.Tconstr _ ->
@@ -41,17 +40,16 @@ let raw_string_of_type_list ?(margin = default_margin) sep type_list =
     | _ -> false
   in
   let print_one_type variance t =
-    Printtyp.mark_loops t;
     if need_parent t then
       (
        Format.fprintf fmt "(%s" variance;
-       Printtyp.type_scheme_max ~b_reset_names: false fmt t;
+       Printtyp.shared_type_scheme fmt t;
        Format.fprintf fmt ")"
       )
     else
       (
        Format.fprintf fmt "%s" variance;
-       Printtyp.type_scheme_max ~b_reset_names: false fmt t
+       Printtyp.shared_type_scheme fmt t
       )
   in
   begin match type_list with
@@ -118,7 +116,7 @@ let string_of_class_type_param_list ?margin l =
     (if par then "]" else "")
 
 let rec is_arrow_type t =
-  match t.Types.desc with
+  match Types.get_desc t with
     Types.Tarrow _ -> true
   | Types.Tlink t2 | Types.Tsubst (t2, _) -> is_arrow_type t2
   (* | Types.Ttuple _ *)
@@ -140,7 +138,6 @@ let string_of_class_params ?(margin = default_margin) c =
             Odoc_misc.remove_option t
           else
             t in
-        Printtyp.mark_loops t;
         Format.fprintf fmt "@[<hov 2>%s%s%a%s@] ->@ "
           (
            match label with
@@ -149,7 +146,7 @@ let string_of_class_params ?(margin = default_margin) c =
             | Asttypes.Optional s -> "?"^s^":"
           )
           (if parent then "(" else "") (* TODO open_box ?*)
-          (Printtyp.type_scheme_max ~b_reset_names:false) ty
+          (Printtyp.shared_type_scheme) ty
           (if parent then ")" else "");
         iter ctype
     | Types.Cty_signature _

--- a/src/odoc_wiki/odoc_wiki.ml
+++ b/src/odoc_wiki/odoc_wiki.ml
@@ -1291,7 +1291,7 @@ module Generator = struct
          | Type_record l ->
            bs b (" "^(self#delimiter "~=")^" ");
            if priv then bs b "private " ;
-           self#html_of_record b indent father l ;
+           self#html_of_record b ~indent ~father l ;
         );
         bs b ">>";
         self#html_of_info b t.ty_info;

--- a/wikidoc.opam
+++ b/wikidoc.opam
@@ -18,7 +18,7 @@ remove: [
   [ "rm" "-f" "%{bin}%/latex_of_wiki" ]
 ]
 depends: [
-  "ocaml" {= "4.14.0" | = "4.14.1" | = "4.14.2"}
+  "ocaml" {>= "4.14.0" & < "5.1.0"}
   "base-threads"
   "base-unix"
   "ocamlfind"

--- a/wikidoc.opam
+++ b/wikidoc.opam
@@ -18,7 +18,7 @@ remove: [
   [ "rm" "-f" "%{bin}%/latex_of_wiki" ]
 ]
 depends: [
-  "ocaml" {>= "4.10.0" & < "4.13.0"}
+  "ocaml" {= "4.13.0"}
   "base-threads"
   "base-unix"
   "ocamlfind"

--- a/wikidoc.opam
+++ b/wikidoc.opam
@@ -18,7 +18,7 @@ remove: [
   [ "rm" "-f" "%{bin}%/latex_of_wiki" ]
 ]
 depends: [
-  "ocaml" {= "4.13.0"}
+  "ocaml" {= "4.14.0" | = "4.14.1" | = "4.14.2"}
   "base-threads"
   "base-unix"
   "ocamlfind"


### PR DESCRIPTION
# Résumé
J'ai fais une autre pull request, pour la version d'OCaml 5.1, mais cela ne fonctionne pas. J'ai donné les explications dans l'autre pull request.

Cette branche fonctionne avec ocaml > 4.13.1 et < 5.1.0.

## Ocaml  4.13 : modification d'un type  
```
File "odoc_import.ml", line 35, characters 23-38:
35 |     | Types.Tlink t2 | Types.Tsubst t2 -> need_parent t2
                            ^^^^^^^^^^^^^^^
Error: The constructor Types.Tsubst expects 2 argument(s),
       but is applied here to 1 argument(s)
make[1]: *** [Makefile:45: odoc_import.cmo] Error 2
```

Vient de ce changement :
https://github.com/ocaml/ocaml/pull/10174

Avant :
```ocaml
| Tsubst of type_expr         (* for copying *)
  (** [Tsubst] is used temporarily to store information in low-level
      functions manipulating representation of types, such as
      instantiation or copy.
```
Après :
```ocaml
| Tsubst of type_expr * type_expr option
  (** [Tsubst] is used temporarily to store information in low-level
      functions manipulating representation of types, such as
      instantiation or copy.
      The first argument contains a copy of the original node.
      The second is available only when the first is the row variable of
      a polymorphic variant.  It then contains a copy of the whole variant.
```

J'ai donc modifié en ignorant le second argument et ça marche :
```ocaml
  | Types.Tlink t2 | Types.Tsubst (t2, _) -> is_arrow_type t2
```

Après j'ai pas trop compris le message de la PR, mais ça dit bien que c'est un extra argument:
> The constructor Tsubst of type_desc has only one type_expr as its argument while it needs two during a copy.
> The two values are currently packed as a Ttuple and wrapped in an extra type_expr before they are fed to Tsubst.
> This style looks quite ad-hoc, and moreover it turned out to be an obstacle in our (@garrigue and me) attempt to make
type_expr an abstract type.
> This PR adds to Tsubst another argument of type type_expr option to eliminate that hackish use of Ttuple.

## Supression d'un warning
Simple changement d'appel de fonction :
```
-           self#html_of_record b indent father l ;
+           self#html_of_record b ~indent ~father l ;
```
Les labels étaient pas préciser ce qui cause maintenant un warning
## mark_loops erreurs
printtyp.mark_loops a disparu à ce commit là : https://github.com/ocaml/ocaml/pull/10488/files

Updated ocamldoc to the new API by: (1) removing unncessary calls to Printtyp.mark_loops which were handled by the formatters; and
(2) replacing Printtyp.type_scheme_max ~b_reset_names: false with Printtyp.shared_type_scheme.

Files modified:

    ocamldoc/odoc_env.ml
    ocamldoc/odoc_print.ml
    ocamldoc/odoc_str.ml
    ocamldoc/odoc_value.ml




Il y a certain morceaux de code qui cause des erreurs quasi identique dans odoc_str.ml, ceux-ci ont été modifié. J'ai donc juste eu à copié les changement.
Y a un autre morceau de code qui n'était pas quasi identique mais ressemblait.
J'ai suivi la recommandation : (2) replacing Printtyp.type_scheme_max ~b_reset_names: false with Printtyp.shared_type_scheme

En ce qui concerne la supression de Printtyp.mark_loops t, c'est dis dans le premier conseil qu'il faut suprimé quand c'est "handled by the formatters", et juste après notre Printtyp.mark_loops t, y a un fmt :
	  Format.fprintf fmt "@[<hov 2>%s%s%a%s@] ->@ "
Donc j'ai supprimé.


